### PR TITLE
Tag Docker image with v0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,5 +70,7 @@ jobs:
       - name: Publish image
         run: |
             echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
+            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:v0
             docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
+            docker push $PUBLIC_IMAGE_NAME:v0
             docker push $PUBLIC_IMAGE_NAME:latest


### PR DESCRIPTION
Each time we build a new image it will be tagged as v0 and as latest. If we want to introduce a breaking change we should tag it as v1. This gives users a choice as to which version of the image to reference.