### PR TITLE
Store Docker image in opensafely-core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 
 env:
   IMAGE_NAME: research-template
-  PUBLIC_IMAGE_NAME: ghcr.io/opensafely/research-template
+  PUBLIC_IMAGE_NAME: ghcr.io/opensafely-core/research-template
   REGISTRY: ghcr.io
 
 on:


### PR DESCRIPTION
We're unable to upload images to a different GitHub organisation, so we're storing it in opensafely-core. This is also what we do for our other Docker images.