### PR TITLE
Add test of dev container

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -1,4 +1,4 @@
-name: Check research template dev container functions
+name: Test research template dev container
 
 on:
   schedule:
@@ -18,8 +18,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: 'research-template/research-template-docker'
-  
-      - name: Build and run dev container task
+
+      - name: Test dev container
         uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
         with:
           runCmd: ./research-template/research-template-docker/tests/dev_container.sh

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -1,0 +1,25 @@
+name: Check research template dev container functions
+
+on:
+  schedule:
+    - cron: "18 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  dev-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout research-template repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'opensafely/research-template'
+
+      - name: Checkout research-template-docker repository in subdirectory
+        uses: actions/checkout@v4
+        with:
+          path: 'research-template/research-template-docker'
+  
+      - name: Build and run dev container task
+        uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
+        with:
+          runCmd: ./research-template/research-template-docker/tests/dev_container.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         test "$devcontainer_image" = "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
     - name: Build and run dev container task
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
       with:
         runCmd: ./research-template/research-template-docker/tests/dev_container.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,40 @@ jobs:
             # Disable compression; the file is already compressed
             compression-level: 0
 
-  publish:
+  test-devcontainer:
     needs: [build-and-test]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download Docker image
+      uses: actions/download-artifact@v4
+      with:
+        name: research-template-image
+        path: /tmp/image
+
+    - name: Import Docker image
+      run: docker load --input /tmp/image/research-template.tar.gz
+
+    - name: Tag Docker image for use with dev container
+      run: docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:v0
+
+    - name: Checkout research template temporary devcontainer dev branch
+      uses: actions/checkout@v4
+      with:
+        repository: opensafely/research-template
+
+    - name: Checkout research-template-docker repository in subdirectory
+      uses: actions/checkout@v4
+      with:
+        path: 'research-template/research-template-docker'
+
+    - name: Build and run dev container task
+      uses: devcontainers/ci@v0.3
+      with:
+        runCmd: ./research-template/research-template-docker/tests/dev_container.sh
+
+  publish:
+    needs: [build-and-test, test-devcontainer]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,10 @@ jobs:
     - name: Import Docker image
       run: docker image load --input /tmp/image/research-template.tar.gz
 
-    - name: Check packages
+    - name: Test packages
       run: just test-packages
 
-    - name: Check R Studio installation
+    - name: Test R Studio installation
       run: just test-rstudio
 
   publish:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install just
+      uses: "opensafely-core/setup-action@v1"
+      with:
+        install-just: true
+
     - name: Download Docker image
       uses: actions/download-artifact@v4
       with:
@@ -63,38 +71,8 @@ jobs:
     - name: Tag Docker image for testing
       run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:dev"
 
-    - name: Checkout research template repository
-      uses: actions/checkout@v4
-      with:
-        repository: opensafely/research-template
-
-    - name: Checkout research-template-docker repository in subdirectory
-      uses: actions/checkout@v4
-      with:
-        path: 'research-template/research-template-docker'
-
-    - name: Install demjson package for jsonlint
-      # Necessary because jq doesn't yet have an option to strip comments.
-      # See https://github.com/jqlang/jq/issues/1571
-      run: |
-        sudo apt-get update
-        sudo apt-get install python3-demjson
-
-    - name: Amend research-template devcontainer.json to use dev image
-      run: |
-        # Necessary because jq doesn't give the option to write to a file.
-        # See https://github.com/jqlang/jq/issues/2418
-        cleaned_json=$(jsonlint --allow comments --format-compactly ".devcontainer/devcontainer.json" |
-          jq --arg variable "$PUBLIC_IMAGE_NAME:dev" '.image |= $variable')
-        echo "$cleaned_json" > ".devcontainer/devcontainer.json"
-
-    # It is necessary to run these tests in the dev container,
-    # because they currently require Docker to correctly discover
-    # the state of the Python packages in the Python action image.
-    - name: Build and run dev container test task
-      uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
-      with:
-        runCmd: ./research-template/research-template-docker/tests/packages.sh
+    - name: Check packages
+      run: just packages-test
 
   publish:
     needs: [build-and-test, test-packages]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             # Disable compression; the file is already compressed
             compression-level: 0
 
-  test-packages:
+  test-docker-image:
     needs: [build-and-test]
     runs-on: ubuntu-latest
 
@@ -74,8 +74,11 @@ jobs:
     - name: Check packages
       run: just test-packages
 
+    - name: Check R Studio installation
+      run: just test-rstudio
+
   publish:
-    needs: [build-and-test, test-packages]
+    needs: [build-and-test, test-docker-image]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         path: /tmp/image
 
     - name: Import Docker image
-      run: docker load --input /tmp/image/research-template.tar.gz
+      run: docker image load --input /tmp/image/research-template.tar.gz
 
     - name: Check packages
       run: just test-packages
@@ -98,7 +98,7 @@ jobs:
             path: /tmp/image
 
       - name: Import docker image
-        run: docker load --input /tmp/image/research-template.tar.gz
+        run: docker image load --input /tmp/image/research-template.tar.gz
 
       - name: Publish image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
             path: /tmp/image
 
       - name: Import docker image
-        run: gunzip -c /tmp/image/research-template.tar.gz | docker load
+        run: docker load --input /tmp/image/research-template.tar.gz
 
       - name: Publish image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,15 @@ jobs:
 
       - name: Save docker image
         run: |
-          docker save research-template | gzip > /tmp/research-template.tar.gz
+          docker save research-template | pigz > /tmp/research-template.tar.gz
 
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:
             name: research-template-image
             path: /tmp/research-template.tar.gz
+            # Disable compression; the file is already compressed
+            compression-level: 0
 
   publish:
     needs: [build-and-test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: CI
 
 env:
   IMAGE_NAME: research-template
+  IMAGE_VERSION: v0
   PUBLIC_IMAGE_NAME: ghcr.io/opensafely-core/research-template
   REGISTRY: ghcr.io
 
@@ -60,7 +61,7 @@ jobs:
       run: docker load --input /tmp/image/research-template.tar.gz
 
     - name: Tag Docker image for use with dev container
-      run: docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:v0
+      run: docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
 
     - name: Checkout research template temporary devcontainer dev branch
       uses: actions/checkout@v4
@@ -71,6 +72,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: 'research-template/research-template-docker'
+
+    - name: Check that we have correct version of image in devcontainer.json
+      # Slightly brittle because jq doesn't strip comments
+      # See https://github.com/jqlang/jq/issues/1571
+      run: |
+        devcontainer_image=$(grep -v "//" .devcontainer/devcontainer.json | jq --raw-output .image)
+        test "$devcontainer_image" = "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
     - name: Build and run dev container task
       uses: devcontainers/ci@v0.3
@@ -106,7 +114,7 @@ jobs:
       - name: Publish image
         run: |
             echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
-            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:v0
+            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
             docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
-            docker push $PUBLIC_IMAGE_NAME:v0
+            docker push $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
             docker push $PUBLIC_IMAGE_NAME:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Build docker image
         run: just build
 
-      - name: Test docker image
-        run: just smoke-test
+      - name: Smoke test docker image
+        run: just test-smoke
 
       - name: Save docker image
         run: |
@@ -72,7 +72,7 @@ jobs:
       run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:dev"
 
     - name: Check packages
-      run: just packages-test
+      run: just test-packages
 
   publish:
     needs: [build-and-test, test-packages]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
     - cron: "0 12 * * SUN"
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,9 +31,6 @@ jobs:
       - name: Build docker image
         run: just build
 
-      - name: Smoke test docker image
-        run: just test-smoke
-
       - name: Save docker image
         run: |
           docker save research-template | pigz --fast > /tmp/research-template.tar.gz
@@ -47,7 +44,7 @@ jobs:
             compression-level: 0
 
   test-docker-image:
-    needs: [build-and-test]
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
@@ -68,14 +65,17 @@ jobs:
     - name: Import Docker image
       run: docker image load --input /tmp/image/research-template.tar.gz
 
-    - name: Test packages
-      run: just test-packages
+    - name: Test Python installation
+      run: just test-python-install
 
     - name: Test R Studio installation
       run: just test-rstudio
 
+    - name: Test packages
+      run: just test-packages
+
   publish:
-    needs: [build-and-test, test-docker-image]
+    needs: [build, test-docker-image]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Tag Docker image for use with dev container
       run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
-    - name: Checkout research template temporary devcontainer dev branch
+    - name: Checkout research template repository
       uses: actions/checkout@v4
       with:
         repository: opensafely/research-template

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,9 +68,6 @@ jobs:
     - name: Import Docker image
       run: docker load --input /tmp/image/research-template.tar.gz
 
-    - name: Tag Docker image for testing
-      run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:dev"
-
     - name: Check packages
       run: just test-packages
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Save docker image
         run: |
-          docker save research-template | pigz > /tmp/research-template.tar.gz
+          docker save research-template | pigz --fast > /tmp/research-template.tar.gz
 
       - name: Upload docker image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
     # It is necessary to run these tests in the dev container,
     # because they currently require Docker to correctly discover
     # the state of the Python packages in the Python action image.
-    - name: Build and run dev container task
+    - name: Build and run dev container test task
       uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
       with:
         runCmd: ./research-template/research-template-docker/tests/packages.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       run: docker load --input /tmp/image/research-template.tar.gz
 
     - name: Tag Docker image for use with dev container
-      run: docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
+      run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
     - name: Checkout research template temporary devcontainer dev branch
       uses: actions/checkout@v4
@@ -73,11 +73,16 @@ jobs:
       with:
         path: 'research-template/research-template-docker'
 
-    - name: Check that we have correct version of image in devcontainer.json
-      # Slightly brittle because jq doesn't strip comments
+    - name: Install demjson package for jsonlint
+      # Necessary because jq doesn't yet have an option to strip comments.
       # See https://github.com/jqlang/jq/issues/1571
       run: |
-        devcontainer_image=$(grep -v "//" .devcontainer/devcontainer.json | jq --raw-output .image)
+        sudo apt-get update
+        sudo apt-get install python3-demjson
+
+    - name: Check that we have correct version of image in devcontainer.json
+      run: |
+        devcontainer_image=$(jsonlint --allow comments --format-compactly ".devcontainer/devcontainer.json" | jq --raw-output .image)
         test "$devcontainer_image" = "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
     - name: Build and run dev container task

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,8 +118,8 @@ jobs:
 
       - name: Publish image
         run: |
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
-            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
-            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
-            docker push $PUBLIC_IMAGE_NAME:$IMAGE_VERSION
-            docker push $PUBLIC_IMAGE_NAME:latest
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login "$REGISTRY" -u ${{ github.actor }} --password-stdin
+            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
+            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
+            docker push "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
+            docker push "$PUBLIC_IMAGE_NAME:latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
     - name: Import Docker image
       run: docker load --input /tmp/image/research-template.tar.gz
 
-    - name: Tag Docker image for use with dev container
-      run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
+    - name: Tag Docker image for testing
+      run: docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:dev"
 
     - name: Checkout research template repository
       uses: actions/checkout@v4
@@ -80,10 +80,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install python3-demjson
 
-    - name: Check that we have correct version of image in devcontainer.json
+    - name: Amend research-template devcontainer.json to use dev image
       run: |
-        devcontainer_image=$(jsonlint --allow comments --format-compactly ".devcontainer/devcontainer.json" | jq --raw-output .image)
-        test "$devcontainer_image" = "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
+        # Necessary because jq doesn't give the option to write to a file.
+        # See https://github.com/jqlang/jq/issues/2418
+        cleaned_json=$(jsonlint --allow comments --format-compactly ".devcontainer/devcontainer.json" |
+          jq --arg variable "$PUBLIC_IMAGE_NAME:dev" '.image |= $variable')
+        echo "$cleaned_json" > ".devcontainer/devcontainer.json"
 
     # It is necessary to run these tests in the dev container,
     # because they currently require Docker to correctly discover

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,9 @@ jobs:
         devcontainer_image=$(jsonlint --allow comments --format-compactly ".devcontainer/devcontainer.json" | jq --raw-output .image)
         test "$devcontainer_image" = "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
 
+    # It is necessary to run these tests in the dev container,
+    # because they currently require Docker to correctly discover
+    # the state of the Python packages in the Python action image.
     - name: Build and run dev container task
       uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             # Disable compression; the file is already compressed
             compression-level: 0
 
-  test-devcontainer:
+  test-packages:
     needs: [build-and-test]
     runs-on: ubuntu-latest
 
@@ -88,10 +88,10 @@ jobs:
     - name: Build and run dev container task
       uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
       with:
-        runCmd: ./research-template/research-template-docker/tests/dev_container.sh
+        runCmd: ./research-template/research-template-docker/tests/packages.sh
 
   publish:
-    needs: [build-and-test, test-devcontainer]
+    needs: [build-and-test, test-packages]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
   publish:
     needs: [build-and-test]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       run: just test-python-install
 
     - name: Test R Studio installation
-      run: just test-rstudio
+      run: just test-rstudio-install
 
     - name: Test packages
       run: just test-packages

--- a/justfile
+++ b/justfile
@@ -11,11 +11,11 @@ check-image-exists:
     # Extra brackets are for Just escaping.
     docker image inspect --format='{{{{.Id}}}}' research-template
 
-test-smoke: check-image-exists
-    docker run --rm research-template ls /opt/venv/bin/python3.10
-
 test-packages: check-image-exists
     tests/packages.sh
+
+test-python-install: check-image-exists
+    docker run -i --entrypoint /bin/bash research-template < ./tests/python.sh
 
 test-rstudio: check-image-exists
     docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh

--- a/justfile
+++ b/justfile
@@ -7,8 +7,8 @@ default:
 build:
     docker build . -t research-template
 
-smoke-test:
+test-smoke:
     docker run --rm research-template ls /opt/venv/bin/python3.10
 
-packages-test:
+test-packages:
     tests/packages.sh

--- a/justfile
+++ b/justfile
@@ -12,3 +12,6 @@ test-smoke:
 
 test-packages:
     tests/packages.sh
+
+test-rstudio:
+    docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh

--- a/justfile
+++ b/justfile
@@ -7,11 +7,15 @@ default:
 build:
     docker build . -t research-template
 
-test-smoke:
+check-image-exists:
+    # Extra brackets are for Just escaping.
+    docker image inspect --format='{{{{.Id}}}}' research-template
+
+test-smoke: check-image-exists
     docker run --rm research-template ls /opt/venv/bin/python3.10
 
-test-packages:
+test-packages: check-image-exists
     tests/packages.sh
 
-test-rstudio:
+test-rstudio: check-image-exists
     docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh

--- a/justfile
+++ b/justfile
@@ -9,3 +9,6 @@ build:
 
 smoke-test:
     docker run --rm research-template ls /opt/venv/bin/python3.10
+
+packages-test:
+    tests/packages.sh

--- a/justfile
+++ b/justfile
@@ -17,5 +17,5 @@ test-packages: check-image-exists
 test-python-install: check-image-exists
     docker run -i --entrypoint /bin/bash research-template < ./tests/python.sh
 
-test-rstudio: check-image-exists
+test-rstudio-install: check-image-exists
     docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -7,46 +7,6 @@ set -euxo pipefail
 # Check the OpenSAFELY research-template example runs.
 opensafely run run_all
 
-# Check that the R packages in the OpenSAFELY R image are available in the dev container.
-# The R setup we have leads to two sources of packages.
-# As a result, this only compares package names;
-# some packages are installed multiple times with different version numbers.
-# See https://github.com/opensafely-core/research-template-docker/issues/22
-
-# These packages are known to be extra to the local installation.
-r_installed_known_extra_packages=$(cat <<-END
-"docopt"
-"littler"
-"spatial"
-END
-)
-
-# This function expects a CSV format with header line:
-# "Package","Version"
-# "SomeRPackage","1.0"
-extract_quoted_package_names_from_csv() {
-    tail -n +2 | \
-    cut -d ',' -f1 | \
-    sort -u
-}
-
-r_docker_packages=$(curl 'https://raw.githubusercontent.com/opensafely-core/r-docker/main/packages.csv' |
-    extract_quoted_package_names_from_csv)
-r_installed_packages=$(Rscript -e 'write.csv(installed.packages()[, c("Package", "Version")], row.names = FALSE)' |
-    extract_quoted_package_names_from_csv)
-r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo "$r_installed_packages"))
-
-[ "$r_packages_extra_to_local_install" == "$r_installed_known_extra_packages" ]
-
-# Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
-# This checks package names and versions.
-python_image_version='v2'
-opensafely pull "python:$python_image_version"
-
-python_docker_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
-python_installed_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
-diff <(echo "$python_docker_packages") <(echo "$python_installed_packages")
-
 # Check the RStudio server is running.
 curl -L 'http://localhost:8787' | grep 'RStudio'
 

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -43,9 +43,9 @@ r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo
 python_image_version='v2'
 opensafely pull "python:$python_image_version"
 
-docker_python_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
-local_python_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
-diff <(echo "$local_python_packages") <(echo "$docker_python_packages")
+python_docker_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
+python_installed_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
+diff <(echo "$python_docker_packages") <(echo "$python_installed_packages")
 
 # Check the RStudio server is running.
 curl -L 'http://localhost:8787' | grep 'RStudio'

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -6,3 +6,9 @@ opensafely run run_all
 
 # Check the RStudio server is running.
 curl -L 'http://localhost:8787' | grep 'RStudio'
+
+# This is a rudimentary placeholder test of the ehrQL installation.
+# We cannot easily run ehrQL because it requires Python 3.11 to be imported,
+# but the OpenSAFELY Python Docker image, and the dev container, uses Python 3.10.
+# In future, we could actually try and import ehrQL through Python.
+ls .devcontainer/ehrql-main/

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Check that we are the rstudio user.
-[ "$(whoami)" == 'rstudio' ]
-
 # Check the OpenSAFELY research-template example runs.
 opensafely run run_all
 
 # Check the RStudio server is running.
 curl -L 'http://localhost:8787' | grep 'RStudio'
-
-# Check the RStudio server installation.
-sudo rstudio-server stop
-sudo rstudio-server verify-installation

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Check that we are the rstudio user.
+[ "$(whoami)" == 'rstudio' ]
+
+# Check the OpenSAFELY research-template example runs.
+opensafely run run_all
+
+# Check the RStudio server is running.
+curl -L 'http://localhost:8787' | grep 'RStudio'
+
+# Check the RStudio server installation.
+sudo rstudio-server stop
+sudo rstudio-server verify-installation

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -7,6 +7,15 @@ set -euxo pipefail
 # Check the OpenSAFELY research-template example runs.
 opensafely run run_all
 
+# Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
+# This checks package names and versions.
+python_image_version='v2'
+opensafely pull "python:$python_image_version"
+
+docker_python_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
+local_python_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
+diff <(echo "$local_python_packages") <(echo "$docker_python_packages")
+
 # Check the RStudio server is running.
 curl -L 'http://localhost:8787' | grep 'RStudio'
 

--- a/tests/dev_container.sh
+++ b/tests/dev_container.sh
@@ -7,6 +7,37 @@ set -euxo pipefail
 # Check the OpenSAFELY research-template example runs.
 opensafely run run_all
 
+# Check that the R packages in the OpenSAFELY R image are available in the dev container.
+# The R setup we have leads to two sources of packages.
+# As a result, this only compares package names;
+# some packages are installed multiple times with different version numbers.
+# See https://github.com/opensafely-core/research-template-docker/issues/22
+
+# These packages are known to be extra to the local installation.
+r_installed_known_extra_packages=$(cat <<-END
+"docopt"
+"littler"
+"spatial"
+END
+)
+
+# This function expects a CSV format with header line:
+# "Package","Version"
+# "SomeRPackage","1.0"
+extract_quoted_package_names_from_csv() {
+    tail -n +2 | \
+    cut -d ',' -f1 | \
+    sort -u
+}
+
+r_docker_packages=$(curl 'https://raw.githubusercontent.com/opensafely-core/r-docker/main/packages.csv' |
+    extract_quoted_package_names_from_csv)
+r_installed_packages=$(Rscript -e 'write.csv(installed.packages()[, c("Package", "Version")], row.names = FALSE)' |
+    extract_quoted_package_names_from_csv)
+r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo "$r_installed_packages"))
+
+[ "$r_packages_extra_to_local_install" == "$r_installed_known_extra_packages" ]
+
 # Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
 # This checks package names and versions.
 python_image_version='v2'

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Check that the R packages in the OpenSAFELY R image are available in the dev container.
+# The R setup we have leads to two sources of packages.
+# As a result, this only compares package names;
+# some packages are installed multiple times with different version numbers.
+# See https://github.com/opensafely-core/research-template-docker/issues/22
+
+# These packages are known to be extra to the local installation.
+r_installed_known_extra_packages=$(cat <<-END
+"docopt"
+"littler"
+"spatial"
+END
+)
+
+# This function expects a CSV format with header line:
+# "Package","Version"
+# "SomeRPackage","1.0"
+extract_quoted_package_names_from_csv() {
+    tail -n +2 | \
+    cut -d ',' -f1 | \
+    sort -u
+}
+
+r_docker_packages=$(curl 'https://raw.githubusercontent.com/opensafely-core/r-docker/main/packages.csv' |
+    extract_quoted_package_names_from_csv)
+r_installed_packages=$(Rscript -e 'write.csv(installed.packages()[, c("Package", "Version")], row.names = FALSE)' |
+    extract_quoted_package_names_from_csv)
+r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo "$r_installed_packages"))
+
+[ "$r_packages_extra_to_local_install" == "$r_installed_known_extra_packages" ]
+
+# Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
+# This checks package names and versions.
+python_image_version='v2'
+opensafely pull "python:$python_image_version"
+
+python_docker_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
+python_installed_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
+diff <(echo "$python_docker_packages") <(echo "$python_installed_packages")

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -35,8 +35,10 @@ r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo
 # Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
 # This checks package names and versions.
 python_image_version='v2'
-opensafely pull "python:$python_image_version"
+python_image="ghcr.io/opensafely-core/python:$python_image_version"
 
-python_docker_packages=$(docker run "ghcr.io/opensafely-core/python:$python_image_version" python -m pip freeze)
+docker pull "$python_image"
+
+python_docker_packages=$(docker run "$python_image" python -m pip freeze)
 python_installed_packages=$(/opt/venv/bin/python3.10 -m pip freeze)
 diff <(echo "$python_docker_packages") <(echo "$python_installed_packages")

--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euxo pipefail
 
+# These checks assume that the packages do not change
+# between building the Docker image in this repository,
+# and checking the packages against the OpenSAFELY R and Python images.
+
 # Check that the R packages in the OpenSAFELY R image are available in the dev container.
 # The R setup we have leads to two sources of packages.
 # As a result, this only compares package names;

--- a/tests/python.sh
+++ b/tests/python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+/opt/venv/bin/python3.10 --version

--- a/tests/r_studio.sh
+++ b/tests/r_studio.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Check that we are the rstudio user.
+[ "$(whoami)" == 'rstudio' ]
+
+# Check the RStudio server installation.
+sudo rstudio-server verify-installation
+sudo rstudio-server start
+
+# Check the RStudio server is running.
+curl -L 'http://localhost:8787' | grep 'RStudio'
+
+sudo rstudio-server stop


### PR DESCRIPTION
This PR partly deals with opensafely-core/codespaces-initiative#18 by:

* making some speed improvements to the CI workflow (even with this additional dev container test, the time is roughly unchanged; the existing `build-and-test` job takes about half the time it did) 
* adding some basic checks of a dev container using the image built from this repository, used with the current research-template dev container configuration