### PR TITLE
Fix redirected/"fake" Python executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
     # Set default python, so that the Python virtualenv works as expected
     rm /usr/bin/python3 &&\
     ln -s /usr/bin/python3.10 /usr/bin/python3 &&\
-    # Create a fake system Python pointing at venv python
-    echo 'exec /opt/venv/bin/python3.10 "$@"' > /usr/bin/python &&\
+    # Create a fake system Python pointing at venv python, allows future redirection
+    # and simplifies vscode config as we can pretend we're just using system python
+    echo -e '#!/bin/bash\nexec /opt/venv/bin/python3.10 "$@"' > /usr/bin/python &&\
+    chmod +x /usr/bin/python &&\
     # Configure RStudio Server to run without auth
     echo "auth-none=1" >> /etc/rstudio/rserver.conf &&\
     echo "USER=rstudio" >> /etc/environment &&\

--- a/justfile
+++ b/justfile
@@ -8,4 +8,4 @@ build:
     docker build . -t research-template
 
 smoke-test:
-    docker run --rm research-template ls /opt/venv/bin/python3.10
+    docker run --rm research-template python --version


### PR DESCRIPTION
We were already redirecting `python` to be the same version of Python available in the OpenSAFELY python docker image (with corresponding venv/packages), however there were two bugs: this script was not executable and it lacked a bash shebang. The lack of executability didn't seem to bother VS Code, but when called from the CLI it obviously failed. The smoke test now actually calls the python executable rather than just checking it exists, which required the addition of a shebang to the script (which it probably should have had all along).

* add bash shebang to redirected python script (to make smoke test work, amongst others)
* make executable
* make smoke test exercise this python