### PR TITLE
Fix cleaning of rocker-provided R library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
     # Configure RStudio Server to run without auth
     echo "auth-none=1" >> /etc/rstudio/rserver.conf &&\
     echo "USER=rstudio" >> /etc/environment &&\
-    # Remove the packages shipped with the rocker image
-    rm -rf /usr/library/lib/R/site-library/* &&\
     # Give the local user sudo (aka root) permissions
     usermod -aG sudo rstudio &&\
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Previously this line tried to delete a nonexistent path, which would have been overwritten by a later `COPY` statement anyway. This now actually achieves the intended functionality of that line, whilst preserving packages required for the proper functioning of RStudio.