### PR TITLE
Fix Docker image import in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
             path: /tmp/image
 
       - name: Import docker image
-        run: docker image load --input /tmp/image/research-template.tar.gz
+        run: docker image load --input /tmp/image/research-template.tar.zst
 
       - name: Publish image
         run: |


### PR DESCRIPTION
Missed this filename had changed in #35.

It got missed because the publish workflow doesn't run unless on a push to `main`.