### PR TITLE
Add Slack notifications for scheduled workflow failures

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -31,3 +31,13 @@ jobs:
         uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
         with:
           runCmd: ./research-template/research-template-docker/tests/dev_container.sh
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C069SADHP1Q
+          status: "Scheduled dev container test run failure"
+          color: danger

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,3 +107,20 @@ jobs:
             docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
             docker push "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
             docker push "$PUBLIC_IMAGE_NAME:latest"
+
+  notify-slack-on-scheduled-failures:
+    needs: [build, test-docker-image, publish]
+
+    runs-on: ubuntu-latest
+
+    if: ${{ !cancelled() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+
+    steps:
+      - name: Notify Slack on failure
+        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel_id: C069SADHP1Q
+          status: "Scheduled Research Template Docker image build or publish failure"
+          color: danger


### PR DESCRIPTION
Fixes #21.

This notifies Slack on scheduled workflow failures only. For runs triggered manually or by CI checks, only GitHub notifications are used, to avoid spamming Slack.