### PR TITLE
Improve the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ LABEL org.opencontainers.image.source https://github.com/opensafely/research-tem
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 
 # DL3008, DL3042: we always want latest package versions when we rebuild
+# DL3009: we are caching apt
 # DL3013: using an apt cache on the host instead
-# hadolint ignore=DL3008,DL3042,DL3013
+# hadolint ignore=DL3008,DL3009,DL3042,DL3013
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/var/cache/apt \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ LABEL org.opencontainers.image.source https://github.com/opensafely/research-tem
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install
-RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # DL3008, DL3042: we always want latest package versions when we rebuild
 # DL3009: we are caching apt
 # DL3013: using an apt cache on the host instead
 # hadolint ignore=DL3008,DL3009,DL3042,DL3013
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
     apt-get update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ LABEL org.opencontainers.image.source https://github.com/opensafely/research-tem
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# DL3008, DL3042: we always want latest package versions when we rebuild
+# DL3008: we always want latest package versions when we rebuild
 # DL3009: we are caching apt
-# DL3013: using an apt cache on the host instead
-# hadolint ignore=DL3008,DL3009,DL3042,DL3013
+# hadolint ignore=DL3008,DL3009
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ LABEL org.opencontainers.image.source https://github.com/opensafely/research-tem
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # DL3008, DL3042: we always want latest package versions when we rebuild
 # DL3009: we are caching apt
 # DL3013: using an apt cache on the host instead
 # hadolint ignore=DL3008,DL3009,DL3042,DL3013
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ LABEL org.opencontainers.image.source https://github.com/opensafely/research-tem
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 
-# DL3042: we always want latest package versions when we rebuild
+# DL3008, DL3042: we always want latest package versions when we rebuild
 # DL3013: using an apt cache on the host instead
-# hadolint ignore=DL3042,DL3013
+# hadolint ignore=DL3008,DL3042,DL3013
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=cache,target=/var/cache/apt \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\


### PR DESCRIPTION
This PR:

* Fixes #14 by ignoring the Hadolint warnings that don't apply to our use.
* Cache `apt` as per the Docker documentation.
* Removes some unused Hadolint ignores.