### PR TITLE
Update Docker `image.source` label to correct URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocker/rstudio:4.0.5
 
-LABEL org.opencontainers.image.source https://github.com/opensafely/research-template
+LABEL org.opencontainers.image.source https://github.com/opensafely-core/research-template-docker
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install


### PR DESCRIPTION
Fixes #39.

From the [relevant specification](https://github.com/opencontainers/image-spec/blob/dd33f727e2faea07432ef6f06d6f9afe73f3f519/annotations.md):

> **org.opencontainers.image.source** URL to get source code for building the image (string)