### PR TITLE
Enable loading of `tidyverse`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "deb http://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
     apt-get update &&\
-    # Install python 3.10. This is the version used by the python-docker 
+    apt-get install -y \
+    # Install python 3.10. This is the version used by the python-docker
     # image, used for analyses using the OpenSAFELY pipeline.
-    apt-get install -y --no-install-recommends curl python3.10 python3.10-distutils python3.10-venv &&\
+    --no-install-recommends curl python3.10 python3.10-distutils python3.10-venv \
+    # Install dependency for R tidyverse package.
+    libxml2 &&\
     # Pip for Python 3.10 isn't included in deadsnakes, so install separately
     curl https://bootstrap.pypa.io/get-pip.py | python3.10 &&\
     # Set default python, so that the Python virtualenv works as expected


### PR DESCRIPTION
Fixes #31.

This was discussed and we initially decided that we should fix these dependency issues on a case-by-case basis.

This was tested locally by building the Docker image and running `library('tidyverse')` inside.

With this commit:

```
> library('tidyverse')
── Attaching packages ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse 1.3.0 ──
✔ ggplot2 3.4.2     ✔ purrr   0.3.4
✔ tibble  3.0.3     ✔ dplyr   1.0.2
✔ tidyr   1.1.2     ✔ stringr 1.4.0
✔ readr   1.3.1     ✔ forcats 0.5.0
── Conflicts ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
…
```

Without this commit, we get the reported behaviour in #31:

```
> library('tidyverse')
Error: package or namespace load failed for ‘tidyverse’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/site-library/xml2/libs/xml2.so':
  libxml2.so.2: cannot open shared object file: No such file or directory
```