### PR TITLE
Add Docker image metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM rocker/rstudio:4.0.5
 
-LABEL org.opencontainers.image.source https://github.com/opensafely-core/research-template-docker
+LABEL org.opencontainers.image.title="Research Template" \
+      org.opencontainers.image.description="Dev container image for the OpenSAFELY research template" \
+      org.opencontainers.image.source="https://github.com/opensafely-core/research-template-docker" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later" \
+      org.opencontainers.image.authors="OpenSAFELY Team <team@opensafely.org>" \
+      org.opencontainers.image.vendor="OpenSAFELY"
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,12 @@ ENV \
     # Required to make Git features such as rebasing work.
     EDITOR="nano"
 
+# The following build details will change.
+# These are the last step to make better use of Docker's build cache,
+# avoiding rebuilding image layers unnecessarily.
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.created=$BUILD_DATE
+ARG GITREF=unknown
+LABEL org.opencontainers.image.revision=$GITREF
+
 USER rstudio

--- a/justfile
+++ b/justfile
@@ -5,7 +5,13 @@ default:
     @"{{ just_executable() }}" --list
 
 build:
-    docker build . -t research-template
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    export GITREF=$(git rev-parse --short HEAD)
+
+    docker build . --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" -t research-template
 
 check-image-exists:
     # Extra brackets are for Just escaping.


### PR DESCRIPTION
Adds metadata to the Docker image, including the datetime of the build and a link to the relevant git commit.

Fixes #40