### PR TITLE
Add more dev container files to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ COPY --chown=rstudio:rstudio --from=ghcr.io/opensafely-core/r:latest /renv/lib/R
 # copy in the MOTD file containing the required help text
 COPY motd /etc/motd
 
+# Copy in auxiliary dev container files.
+# These reside in this repository
+# to minimise the dev container configuration in the research-template repository.
+COPY devcontainer/ /opt/devcontainer/
+
 ENV \
     # Required for installing opensafely cli
     PATH="/home/rstudio/.local/bin:${PATH}" \

--- a/devcontainer/postAttach.sh
+++ b/devcontainer/postAttach.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo rstudio-server start

--- a/devcontainer/postCreate.sh
+++ b/devcontainer/postCreate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail 
+
+/usr/local/bin/pip3 install --user -r .devcontainer/requirements.in
+
+#set R working directory
+! grep -q "$1" $R_HOME/etc/Rprofile.site && sudo tee -a $R_HOME/etc/Rprofile.site <<< "setwd(\"$1\")"
+#set RStudio working directory
+! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json 
+
+#download and extract latest ehrql source
+wget https://github.com/opensafely-core/ehrql/archive/main.zip -P .devcontainer
+unzip -o .devcontainer/main.zip -d .devcontainer/
+rm .devcontainer/main.zip

--- a/devcontainer/postCreate.sh
+++ b/devcontainer/postCreate.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -euo pipefail 
+set -euo pipefail
 
 /usr/local/bin/pip3 install --user -r .devcontainer/requirements.in
 
 #set R working directory
 ! grep -q "$1" $R_HOME/etc/Rprofile.site && sudo tee -a $R_HOME/etc/Rprofile.site <<< "setwd(\"$1\")"
 #set RStudio working directory
-! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json 
+! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json
 
 #download and extract latest ehrql source
 wget https://github.com/opensafely-core/ehrql/archive/main.zip -P .devcontainer

--- a/devcontainer/requirements.in
+++ b/devcontainer/requirements.in
@@ -1,0 +1,1 @@
+opensafely


### PR DESCRIPTION
This PR partly addresses #29.

Before taking any real effect, this will require separate changes in the `research-template` to use the files as added to the Docker image, instead of those in the `research-template` repository.