### PR TITLE
Add a workflow to test development Docker images

### DIFF
--- a/.github/workflows/dev_container_qa.yml
+++ b/.github/workflows/dev_container_qa.yml
@@ -1,0 +1,60 @@
+# This workflow tests that the dev container configuration within
+# opensafely/research-template is correct with respect to the tests within
+# `tests/dev_container.sh`. Notice that the dev container configuration lives in a
+# different repository. This is because opensafely/research-template is a template
+# repository; its contents are copied to multiple other repositories. Rather than test
+# the dev container configuration in each of these multiple other repositories, we test
+# it here, and assume that the copies don't deviate from the template repository. Doing
+# so reduces the cost of updating the tests.
+#
+# This workflow is specifically for testing changes in the Docker build
+# that affect the dev container, before merging them.
+name: Test research template dev container for QA purposes
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dev-container-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout research-template repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'opensafely/research-template'
+
+      - name: Checkout research-template-docker repository in subdirectory
+        uses: actions/checkout@v4
+        with:
+          path: 'research-template/research-template-docker'
+
+      - name: Install just
+        uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
+
+      - name: Build Docker image
+        run: just research-template/research-template-docker/build
+
+      - name: Tag Docker image
+        run: docker tag 'research-template' 'research-template:dev'
+
+      - name: Install demjson package for jsonlint
+        # Necessary because jq doesn't yet have an option to strip comments.
+        # See https://github.com/jqlang/jq/issues/1571
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-demjson
+
+      - name: Amend dev container configuration to use the locally built Docker image
+        run: |
+          echo "Updating devcontainer.json…"
+          devcontainer_json="$(jsonlint --allow comments --format-compactly '.devcontainer/devcontainer.json' | jq '.image = "research-template:dev"')"
+          echo "$devcontainer_json" > '.devcontainer/devcontainer.json'
+          echo "Updated devcontainer.json to:"
+          jq . '.devcontainer/devcontainer.json'
+
+      - name: Test dev container
+        uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.1900000349
+        with:
+          runCmd: ./research-template/research-template-docker/tests/dev_container.sh


### PR DESCRIPTION
Adding this as a proposal only. If others think it's useful, we can merge or refine it.

This workflow build the Docker image for a branch. It then runs the dev container tests using that branch-built image, instead of the image specified in the research-template dev container configuration.

For recent PRs in this repository, I've found it useful to test Docker image changes in a dev container and confirm the tests still run. This helps to avoid a cycle of merge PR, publish an image, manually test the dev container and find it fails, to then have to fix up the image.

This workflow allows for manually triggering such a check. It is not scheduled to run on every commit, nor intended to do so.