### PR TITLE
Turn on  RStudio autosave

### DIFF
--- a/devcontainer/postCreate.sh
+++ b/devcontainer/postCreate.sh
@@ -18,6 +18,10 @@ set_rstudio_pref() {
 #set RStudio working directory
 set_rstudio_pref "initial_working_directory" "\"$1\""
 
+#turn on RStudio autosave
+set_rstudio_pref "auto_save_on_blur" "true"
+set_rstudio_pref "auto_save_on_idle" "\"commit\""
+
 #download and extract latest ehrql source
 wget https://github.com/opensafely-core/ehrql/archive/main.zip -P .devcontainer
 unzip -o .devcontainer/main.zip -d .devcontainer/

--- a/tests/postCreate.sh
+++ b/tests/postCreate.sh
@@ -16,8 +16,11 @@ opensafely --version
 # check R working directory
 [ "$(Rscript -e 'getwd()')" == '[1] "/tmp/testdir"' ]
 
-# check Rstudio working directory
+# check Rstudio preferences
 [ "$(jq '.initial_working_directory' < ~/.config/rstudio/rstudio-prefs.json )" == '"/tmp/testdir"' ]
+[ "$(jq '.auto_save_on_blur' < ~/.config/rstudio/rstudio-prefs.json )" == 'true' ]
+[ "$(jq '.auto_save_on_idle' < ~/.config/rstudio/rstudio-prefs.json )" == '"commit"' ]
+
 
 # check preexisting Rstudio preference
 [ "$(jq '.posix_terminal_shell' < ~/.config/rstudio/rstudio-prefs.json )" == '"bash"' ]


### PR DESCRIPTION
Fixes #61 

Sets the "Automatically save when editor loses focus" and "Save and write changes when editor is idle" settings.