### PR TITLE
Add test for postCreate.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
     - name: Test packages
       run: just test-packages
 
+    - name: Test postCreate script
+      run: just test-postcreate-script
+
   publish:
     needs: [build, test-docker-image]
 

--- a/devcontainer/postCreate.sh
+++ b/devcontainer/postCreate.sh
@@ -7,7 +7,16 @@ set -euo pipefail
 #set R working directory
 ! grep -q "$1" $R_HOME/etc/Rprofile.site && sudo tee -a $R_HOME/etc/Rprofile.site <<< "setwd(\"$1\")"
 #set RStudio working directory
-! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json
+set_rstudio_pref() {
+    key="$1"
+    value="$2"
+    orig_prefs=$(jq -ne "input ? // {}" < ~/.config/rstudio/rstudio-prefs.json)
+    new_prefs=$(jq "if has(\"$key\") then . else . + {\"$key\": $value} end" <<< "$orig_prefs")
+    echo "$new_prefs" > ~/.config/rstudio/rstudio-prefs.json
+}
+
+#set RStudio working directory
+set_rstudio_pref "initial_working_directory" "\"$1\""
 
 #download and extract latest ehrql source
 wget https://github.com/opensafely-core/ehrql/archive/main.zip -P .devcontainer

--- a/justfile
+++ b/justfile
@@ -25,3 +25,6 @@ test-python-install: check-image-exists
 
 test-rstudio-install: check-image-exists
     docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh
+
+test-postcreate-script: check-image-exists
+    docker run -i --entrypoint /bin/bash research-template < ./tests/postCreate.sh

--- a/justfile
+++ b/justfile
@@ -21,10 +21,10 @@ test-packages: check-image-exists
     tests/packages.sh
 
 test-python-install: check-image-exists
-    docker run -i --entrypoint /bin/bash research-template < ./tests/python.sh
+    docker run -i --rm --entrypoint /bin/bash research-template < ./tests/python.sh
 
 test-rstudio-install: check-image-exists
-    docker run -i --entrypoint /bin/bash research-template < ./tests/r_studio.sh
+    docker run -i --rm --entrypoint /bin/bash research-template < ./tests/r_studio.sh
 
 test-postcreate-script: check-image-exists
-    docker run -i --entrypoint /bin/bash research-template < ./tests/postCreate.sh
+    docker run -i --rm --entrypoint /bin/bash research-template < ./tests/postCreate.sh

--- a/tests/postCreate.sh
+++ b/tests/postCreate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euxo pipefail
+
+# postCreate script requirements
+cd ~
+mkdir .devcontainer
+mkdir -p /tmp/testdir
+sudo apt-get -qq update && sudo apt-get install -qq -y jq;
+
+# run postcreate script
+. /opt/devcontainer/postCreate.sh "/tmp/testdir"
+
+# check opensafely CLI installed
+opensafely --version
+
+# check R working directory
+[ "$(Rscript -e 'getwd()')" == '[1] "/tmp/testdir"' ]
+
+# check Rstudio working directory
+[ "$(jq '.initial_working_directory' < ~/.config/rstudio/rstudio-prefs.json )" == '"/tmp/testdir"' ]
+
+# check preexisting Rstudio preference
+[ "$(jq '.posix_terminal_shell' < ~/.config/rstudio/rstudio-prefs.json )" == '"bash"' ]
+
+# check ehrql source present
+[ -d .devcontainer/ehrql-main ]
+
+# check ehrql zip file removed
+[ ! -f .devcontainer/main.zip ]


### PR DESCRIPTION
In the process of #64 I found there weren't any tests for `postCreate.sh` which make it hard to be assured the changes I was making were working.

This branch adds such tests, and I have found that the pre-existing `postCreate.sh` was failing them ( `just test-postcreate-script` should fail at 078208a63e6fa7bd2a3ba617025e469583eac24c or earlier).

I therefore have included a fix for that failure in 5bae9217daf87a477ae296f598e5ab65b0b4cade. 

I'm not sure what's different about the codespaces/devcontainer setup that meant that these settings would have ever been set correctly with the previous code, but the tests added here seem to trigger (and fail on) the "blank RStudio preferences file" scenario described in [this issue](https://github.com/opensafely/research-template/issues/130). I'm not 100% confident that the changes in this PR that make that test pass will fix that issue, but believe having some tests is better than no tests at all.