### PR TITLE
Add remaining system packages for Codespaces R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     # Install python 3.10. This is the version used by the python-docker
     # image, used for analyses using the OpenSAFELY pipeline.
     --no-install-recommends curl python3.10 python3.10-distutils python3.10-venv \
-    # Install dependencies for R tidyverse, knitr, and dagitty packages.
-    libxml2 libmagick++-6.q16-8 libnode-dev &&\
+    # Install dependencies for R tidyverse, knitr, dagitty, units, sf, rgdal, rgeos, odbc, and tcltk packages.
+    libxml2 libmagick++-6.q16-8 libnode-dev libudunits2-0 libgdal26 libodbc1 libtk8.6 &&\
     # Pip for Python 3.10 isn't included in deadsnakes, so install separately
     curl https://bootstrap.pypa.io/get-pip.py | python3.10 &&\
     # Set default python, so that the Python virtualenv works as expected

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ build:
     export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     export GITREF=$(git rev-parse --short HEAD)
 
-    docker build . --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" -t research-template
+    docker build . --platform linux/amd64 --build-arg BUILD_DATE="$BUILD_DATE" --build-arg GITREF="$GITREF" -t research-template
 
 check-image-exists:
     # Extra brackets are for Just escaping.

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ build:
 
 check-image-exists:
     # Extra brackets are for Just escaping.
-    docker image inspect --format='{{{{.Id}}}}' research-template
+    docker image inspect --format='{{{{.Id}}' research-template
 
 test-packages: check-image-exists
     tests/packages.sh


### PR DESCRIPTION
This adds the system packages required at runtime for the following R packages: sf, rgdal, rgeos, units, tcltk, odbc.

Also two other minor tweaks
 * allow building on Apple Silicon Macs
 * fix escaping in Justfile, only the opening double curly braces need to be escaped, <https://github.com/casey/just/issues/352#issuecomment-806335697>