### PR TITLE
Fix changes in r:v1 image packaging

### DIFF
--- a/tests/packages.sh
+++ b/tests/packages.sh
@@ -17,30 +17,40 @@ docker image inspect "$research_template_image" > /dev/null
 # some packages are installed multiple times with different version numbers.
 # See https://github.com/opensafely-core/research-template-docker/issues/22
 
-# These packages are known to be extra to the local installation.
-r_installed_known_extra_packages=$(cat <<-END
+# These packages are known to be extra to the local installation. Must be sorted.
+r_installed_known_extra_packages=$(cat <<END
 "docopt"
 "littler"
 "spatial"
 END
 )
 
-# This function expects a CSV format with header line:
-# "Package","Version"
-# "SomeRPackage","1.0"
-extract_quoted_package_names_from_csv() {
-    tail -n +2 | \
-    cut -d ',' -f1 | \
-    sort -u
+extract_quoted_package_names_from_json() {
+    jq '.Packages | keys[]' | sort -u
 }
 
-r_docker_packages=$(curl 'https://raw.githubusercontent.com/opensafely-core/r-docker/main/packages.csv' |
-    extract_quoted_package_names_from_csv)
-r_installed_packages=$(docker run -i "$research_template_image" /bin/bash -c "Rscript -e 'write.csv(installed.packages()[, c(\"Package\", \"Version\")], row.names = FALSE)'" |
-    extract_quoted_package_names_from_csv)
-r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo "$r_installed_packages"))
+r_docker_packages=$(curl -s 'https://raw.githubusercontent.com/opensafely-core/r-docker/main/v1/renv.lock' | extract_quoted_package_names_from_json)
 
-[ "$r_packages_extra_to_local_install" == "$r_installed_known_extra_packages" ]
+r_script="
+t <- tempfile()
+n=file(nullfile(), open='wt')
+sink(n) # stdout
+sink(n, type='message')  # stderr
+renv::snapshot(lockfile=t, type='all')
+sink()
+sink(type = 'message')
+cat(readLines(t))
+"
+r_installed_packages=$(docker run -i "$research_template_image" Rscript -e "$r_script" | extract_quoted_package_names_from_json)
+
+r_packages_extra_to_local_install=$(comm -13 <(echo "$r_docker_packages") <(echo "$r_installed_packages") | awk NF | sort -u)
+
+if [ "$r_packages_extra_to_local_install" != "$r_installed_known_extra_packages" ]; then
+    set +x
+    echo "There are unexpected extra R packages installed:"
+    comm -13 <(echo "$r_installed_known_extra_packages") <(echo "$r_packages_extra_to_local_install") 
+    exit 1;
+fi
 
 # Check that the Python packages in the OpenSAFELY Python image are available in the dev container.
 # This checks package names and versions.


### PR DESCRIPTION
We switched the r:v1 package metadata to use a markdown file rather than
a csv, which broke this test, as we removed the csv in the r-docker
repo.

This change updates the test to use the renv.lock file instead. However,
unlike the packages.csv , this does not include the base packages
provided by R itself. Since the test still uses the csv output for the
devcontainer image, we needed to add that list of packages to the
expected extra packages for the test.

Also improved the test output when failing to tell the developer
specifically that extra R packages were found, and which ones.