### PR TITLE
Use opensafely launch rstudio to provide rstudio

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -21,3 +21,20 @@ just #  shortcut for just --list
 ## Build instructions
 
 Run `just build` to build the Docker image.
+
+## Local vscode testing
+
+Simplest way to test is to clone the research-template, which will have the
+latest devcontainer set up.
+
+```
+git clone https://github.com/opensafely/research-template
+```
+
+You will then need to edit its .devcontainer/devcontainer.json to use just
+"research-template", rather than the fully qualified ghcr.io/... name.  This
+will now use your locally build image.
+
+You can then run `code .` in that directory, and then Ctrl-Shift-P, type
+"rebuild", and select "Rebuild With Cache and Open in Container" This will
+ensure your devconatainer will use your local image changes.

--- a/devcontainer/postAttach.sh
+++ b/devcontainer/postAttach.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-sudo rstudio-server start
+set -eu
+test -f project.yaml || exit
+images=$(opensafely info --list-project-images | sort | uniq)
+if [[ "$images" =~ "r:v2" ]]; then
+    opensafely launch rstudio:v2 --port 8787 --background --no-browser
+else
+    opensafely launch rstudio:v1 --port 8787 --background --no-browser
+fi


### PR DESCRIPTION
This includes detecting which version of the r image a project is using, and launching the correct version.

The R autocompletion in vscode editor is still based on the dev container version of R, which is the v1.

This free's us from needing to use Rocker as a base image to get rstudio, but changing that is a later task.

Fixes #89 