### PR TITLE
Add cooldown for Dependabot GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
To match our dependency updates policy.