### PR TITLE
Harden repository configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
     cooldown:
       default-days: 7
 
@@ -13,5 +16,8 @@ updates:
       - "**/*"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
     cooldown:
       default-days: 7

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -21,11 +21,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: 'opensafely/research-template'
+          persist-credentials: false
 
       - name: Checkout research-template-docker repository in subdirectory
         uses: actions/checkout@v7
         with:
           path: 'research-template/research-template-docker'
+          persist-credentials: false
 
       - name: Test dev container
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -13,6 +13,9 @@ on:
     - cron: "18 8 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dev-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout research-template repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'opensafely/research-template'
           persist-credentials: false
 
       - name: Checkout research-template-docker repository in subdirectory
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: 'research-template/research-template-docker'
           persist-credentials: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         # Lint the dockerfile before building
         with:
           failure-threshold: error
-      - uses: "opensafely-core/setup-action@v1.6.1"
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -43,7 +43,7 @@ jobs:
           docker image save research-template | zstd --fast -o /tmp/research-template.tar.zst
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: research-template-image
             path: /tmp/research-template.tar.zst
@@ -56,17 +56,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
     - name: Install just
-      uses: "opensafely-core/setup-action@v1.6.1"
+      uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
       with:
         install-just: true
 
     - name: Download Docker image
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: research-template-image
         path: /tmp/image
@@ -98,15 +98,15 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: "opensafely-core/setup-action@v1.6.1"
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
       - name: Download docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: research-template-image
             path: /tmp/image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ on:
   schedule:
     - cron: "0 12 * * SUN"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         # Lint the dockerfile before building
         with:
@@ -55,6 +57,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Install just
       uses: "opensafely-core/setup-action@v1.6.1"
@@ -95,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: "opensafely-core/setup-action@v1.6.1"
         with:
           install-just: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Publish image
         run: |
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login "$REGISTRY" -u ${{ github.actor }} --password-stdin
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login "$REGISTRY" -u ${GITHUB_ACTOR} --password-stdin
             docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"
             docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
             docker push "$PUBLIC_IMAGE_NAME:$IMAGE_VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/rstudio:4.0.5
+FROM rocker/rstudio:4.0.5@sha256:0f3da9a4708fa208c3abe215aa77e3b96b7ebbf3b5e646c97539df53abc97a92
 
 LABEL org.opencontainers.image.title="Research Template" \
       org.opencontainers.image.description="Dev container image for the OpenSAFELY research template" \


### PR DESCRIPTION
Improve various parts of the repository configuration:

* Make slight security improvements to workflows:
  * avoid template injection
  * avoid persisting checkout credentials
  * set permissions in workflows
  * pin the GitHub Actions used
* Pin the Docker image used
* Configure Dependabot for Docker
* Set a weekly update for GitHub Actions